### PR TITLE
Login command should not exit with non-zero code when already logged in

### DIFF
--- a/login.js
+++ b/login.js
@@ -8,7 +8,7 @@ const keyPath = '/gcp-key.json';
 const result = await execa('gcloud', ['auth', 'list']);
 if (!result.stderr.includes('No credentialed accounts')) {
   console.error('You are already logged in');
-  process.exit(1);
+  process.exit(0);
 }
 
 // Verify existence of key file


### PR DESCRIPTION
Having an issue with this when running it in a bash script which has `set -e`